### PR TITLE
Add Kuadrant overlay

### DIFF
--- a/overlays/kuadrant/kustomization.yml
+++ b/overlays/kuadrant/kustomization.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/go-httpbin/
+  - ../../base/mockserver/
+
+images:
+  - name: quay.io/rh_integration/go-httpbin
+    newName: docker.io/mccutchen/go-httpbin
+    newTag: latest


### PR DESCRIPTION
Only httpbin-go and mockserver are needed for now. I used the upstream image for httpbin-go, as I do not need our patches and need a publicly available image.