### PR TITLE
New upstream image location for mailhog & go-httpbin

### DIFF
--- a/base/go-httpbin/deployment-config.yaml
+++ b/base/go-httpbin/deployment-config.yaml
@@ -31,7 +31,7 @@ spec:
               value: /tls/tls.crt
             - name: HTTPS_KEY_FILE
               value: /tls/tls.key
-          image: quay.io/rh_integration/go-httpbin:smadis
+          image: ghcr.io/3scale-qe/go-httpbin:latest
           imagePullPolicy: IfNotPresent
           name: go-httpbin
           ports:

--- a/base/mailhog/deployment.yaml
+++ b/base/mailhog/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         deployment: mailhog
     spec:
       containers:
-        - image: docker.io/mailhog/mailhog:latest
+        - image: ghcr.io/3scale-qe/mailhog-container:latest
           imagePullPolicy: IfNotPresent
           name: mailhog
           ports:

--- a/overlays/template/kustomization.yaml
+++ b/overlays/template/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: quay.io/rh_integration/httpbin
     newName: quay.io/rh_integration/httpbin
     newTag: smadis
-  - name: quay.io/rh_integration/go-httpbin
+  - name: ghcr.io/3scale-qe/go-httpbin
     newName: quay.io/rh_integration/go-httpbin
     newTag: smadis
   - name: quay.io/rh_integration/requestbin


### PR DESCRIPTION
New image references contain multi-arch images
