### PR TITLE
Remove echo-api from testsuite customization

### DIFF
--- a/overlays/testsuite/kustomization.yaml
+++ b/overlays/testsuite/kustomization.yaml
@@ -3,7 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base/echo-api/
   - ../../base/fuse-proxy/
   - ../../base/go-httpbin/
   - ../../base/jaeger/


### PR DESCRIPTION
echo-api is not needed anymore
