### PR TITLE
Create pull-secret if provided

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,17 @@
 
 cd `dirname $0`
 
-oc apply -k overlays/testsuite/ --namespace "${SHARED_NAMESPACE:=tools}"
+SHARED_NAMESPACE="${SHARED_NAMESPACE:=tools}"
+
+if [ -n "$DOCKERCONFIGJSON" ]; then
+	oc get project "$SHARED_NAMESPACE" || oc new-project "$SHARED_NAMESPACE" --skip-config-write=true
+	_oc="oc -n $SHARED_NAMESPACE"
+	$_oc get secret pull-secret \
+		|| ( $_oc create secret generic pull-secret --from-file .dockerconfigjson="$DOCKERCONFIGJSON" --type=kubernetes.io/dockerconfigjson \
+			&& $_oc secrets link default pull-secret --for=pull )
+fi
+
+oc apply -k overlays/testsuite/ --namespace "${SHARED_NAMESPACE}"
 
 NAMESPACE=$SHARED_NAMESPACE ./base/rhsso/deploy-rhsso.sh
 


### PR DESCRIPTION
Let the run.sh create the tools namespace and necessary pull-secret if
content for pull-secret is provided. The content is docker config
referenced via DOCKERCONFIGJSON env variable.

DOCKERCONFIGJSON is intentionally different from DOCKER_CONFIG used to
provide alternate config location and the name is inspired by name of
relevant openshift object.
