### PR TITLE
Wait longer for deployment of apicast-operator

### DIFF
--- a/base/apicast-operator/deploy-apicast.sh
+++ b/base/apicast-operator/deploy-apicast.sh
@@ -3,7 +3,7 @@
 set -exuo pipefail
 command -v envsubst
 
-TIMEOUT_TIME=5   # each 5sec: 5 * 5sec = 25sec
+TIMEOUT_TIME=10   # each 5sec: 10 * 5sec = 50sec
 FILE_ROOT=${BASH_SOURCE%/*}
 NAMESPACE=${NAMESPACE:="apicast-ga"}
 


### PR DESCRIPTION
Some deployments may be slower than usual, more time could be needed for
operator to be ready.
