### PR TITLE
Add jaeger to kuadrant overlay

### DIFF
--- a/overlays/kuadrant/kustomization.yml
+++ b/overlays/kuadrant/kustomization.yml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ../../base/go-httpbin/
   - ../../base/mockserver/
+  - ../../base/jaeger/
 
 images:
   - name: quay.io/rh_integration/go-httpbin


### PR DESCRIPTION
Required for tracing tests on the kuadrant testsuite