### PR TITLE
Add https-client-auth configuration to Keycloak deployments

### DIFF
--- a/base/keycloak-deployment/deployment.yaml
+++ b/base/keycloak-deployment/deployment.yaml
@@ -20,6 +20,7 @@ spec:
           args:
             - start-dev
             - --health-enabled=true
+            - --https-client-auth=request
           startupProbe:
             httpGet:
               path: /health/ready

--- a/base/rhbk/sso-keycloak.yaml.tpl
+++ b/base/rhbk/sso-keycloak.yaml.tpl
@@ -28,6 +28,9 @@ spec:
     tlsSecret: keycloak-tls
   ingress:
     enabled: false
+  additionalOptions:
+    - name: https-client-auth
+      value: request
   unsupported:
     podTemplate:
       spec:

--- a/base/rhsso/sso-keycloak.yaml
+++ b/base/rhsso/sso-keycloak.yaml
@@ -8,4 +8,7 @@ metadata:
 spec:
   externalAccess:
     enabled: true
+  additionalOptions:
+    - name: https-client-auth
+      value: request
   instances: 1


### PR DESCRIPTION
Configure all Keycloak deployments (RHBK, RHSSO, and keycloak-deployment) to request client certificates for HTTPS connections by adding the https-client-auth=request option. This enables mutual TLS authentication when clients provide certificates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Needs to be tested first!